### PR TITLE
fix: only skip reboot on containers, not all molecule testing (like v…

### DIFF
--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -9,7 +9,7 @@
   reboot:
     reboot_timeout: >
       {{ reboot_timeout|int }}
-  tags: molecule-notest
   when:
+    - ansible_virtualization_type not in [ 'docker', 'container', 'containerd' ]
     - not reboot_postponed|bool
     - reboot_needed|bool or reboot_forced|bool


### PR DESCRIPTION
…agrant/virtualbox)